### PR TITLE
Added additional API method stubs

### DIFF
--- a/braindocsclient/bdAPI.py
+++ b/braindocsclient/bdAPI.py
@@ -42,6 +42,20 @@ class BraindocsApi(object):
         agents = r.json()
         return agents
 
+    def doSimilarityAnalysis(self, analysisConfig):
+        """
+        {
+            "agentIds": ["agentId1", "agentId2", ...],
+            "libraryId": "libraryId",
+            "name": "Name of new similarity analysis",
+            "handleWindow": 0 or 1
+        }
+        """
+        r = self.session.post(self.baseURL + '/doSimilarityAnalysis', json=analysisConfig, verify=False)
+        return r.json()
+
+    #def analyze(self,agentId)
+
     def createLibrary(self, libraryContent):
         """
         libraryContent = {
@@ -61,5 +75,6 @@ class BraindocsApi(object):
             ]
         }
         """
+        print libraryContent
         r = self.session.post(self.baseURL + '/library', json=libraryContent, verify=False)
         return r.json()

--- a/braindocsclient/bdAPI.py
+++ b/braindocsclient/bdAPI.py
@@ -43,7 +43,6 @@ class BraindocsApi(object):
         return agents
 
     def createLibrary(self, libraryContent):
-        # WARN(erh): This doesn't seem to be working
         """
         libraryContent = {
             "name":"Name of new library",
@@ -62,5 +61,5 @@ class BraindocsApi(object):
             ]
         }
         """
-        r = self.session.post(self.baseURL + '/library', data=libraryContent, verify=False)
+        r = self.session.post(self.baseURL + '/library', json=libraryContent, verify=False)
         return r.json()

--- a/braindocsclient/bdAPI.py
+++ b/braindocsclient/bdAPI.py
@@ -3,6 +3,7 @@
 """
 
 import requests
+import json
 
 # turn off warnings
 requests.packages.urllib3.disable_warnings()
@@ -16,6 +17,16 @@ class BraindocsApi(object):
         loginData = {'username':username, 'password':password}
         r = self.session.post(baseURL + '/login', data=loginData, verify=False)
 
+    def getLibraries(self):
+        r = self.session.get(self.baseURL + '/getLibraries', verify=False)
+        libraries = r.json()
+        return json.dumps(libraries)
+
+    def getLibraryStatus(self, id):
+        r = self.session.get(self.baseURL + '/getLibraryStatus?libraryId=' + id, verify=False);
+        libraryStatus = r.json()
+        return libraryStatus
+
     def getAnalysisResults(self):
         r = self.session.get(self.baseURL + '/getAnalysisResults', verify=False)
         analysisResults = r.json()
@@ -25,4 +36,31 @@ class BraindocsApi(object):
         r = self.session.get(self.baseURL + '/getAnalysisDetailsTextUnits?analysisId=' + id, verify=False)
         analysisResults = r.json()
         return analysisResults
-        
+
+    def getAgents(self):
+        r = self.session.get(self.baseURL + '/getAgents', verify=False)
+        agents = r.json()
+        return agents
+
+    def createLibrary(self, libraryContent):
+        # WARN(erh): This doesn't seem to be working
+        """
+        libraryContent = {
+            "name":"Name of new library",
+            "description":"Description of new library",
+            "docs": [
+                {
+                    "id":"123",
+                    "filename":"doc123",
+                    "doc":"This is the text for document 123."
+                },
+                {
+                    "id":"abc",
+                    "filename":"docabc",
+                    "doc":"This is the text for document abc."
+                }
+            ]
+        }
+        """
+        r = self.session.post(self.baseURL + '/library', data=libraryContent, verify=False)
+        return r.json()


### PR DESCRIPTION
I added some of the additional API methods to the python library.

createLibrary() doesn't seem to be working. It properly returns the "OK"
JSON message, but the BrainDocs client is showing six separate empty files
in the library.

```
 print bd.createLibrary({
     "name": 'Test',
     "description": "This is a test of library creation.",
     "docs": [
         {
             "id": "1",
             "filename": "1.txt",
             "doc": "This is the text of document 1.",
         },
         {
            "id": "2",
            "filename": "2.txt",
            "doc": "This is the text of document 2.",
        }
    ]
})
```
